### PR TITLE
Save container.name to container logs

### DIFF
--- a/app/models/container_log.rb
+++ b/app/models/container_log.rb
@@ -4,6 +4,7 @@ class ContainerLog
 
   field :type, type: String
   field :data, type: String
+  field :name, type: String
 
   belongs_to :grid
   belongs_to :grid_service
@@ -12,5 +13,6 @@ class ContainerLog
   index({ grid_id: 1 })
   index({ grid_service_id: 1 })
   index({ container_id: 1 })
+  index({ name: 1 })
   index({ data: 'text' })
 end

--- a/app/services/agent/message_handler.rb
+++ b/app/services/agent/message_handler.rb
@@ -97,6 +97,7 @@ module Agent
             grid_service: container.grid_service,
             container: container,
             created_at: created_at,
+            name: container.name,
             type: data['type'],
             data: data['data']
         )

--- a/spec/models/container_log_spec.rb
+++ b/spec/models/container_log_spec.rb
@@ -2,7 +2,7 @@ require_relative '../spec_helper'
 
 describe ContainerLog do
   it { should be_timestamped_document }
-  it { should have_fields(:type, :data)}
+  it { should have_fields(:type, :data, :name)}
 
   it { should belong_to(:grid) }
   it { should belong_to(:grid_service) }
@@ -12,5 +12,6 @@ describe ContainerLog do
   it { should have_index_for(container_id: 1) }
   it { should have_index_for(grid_id: 1) }
   it { should have_index_for(grid_service_id: 1) }
+  it { should have_index_for(name: 1) }
   it { should have_index_for(data: 'text') }
 end

--- a/spec/services/agent/message_handler_spec.rb
+++ b/spec/services/agent/message_handler_spec.rb
@@ -13,4 +13,37 @@ describe Agent::MessageHandler do
       }.to change{ grid.containers.count }.by(-1)
     end
   end
+
+  describe '#on_container_log' do
+    it 'creates new container log entry if container exists' do
+      container = grid.containers.create!(container_id: SecureRandom.hex(16), name: 'foo-1')
+      expect {
+        subject.on_container_log(grid, {
+          'id' => container.container_id,
+          'data' => 'foo',
+          'type' => 'stderr'
+        })
+      }.to change{ grid.container_logs.count }.by(1)
+    end
+
+    it 'saves container.name to log' do
+      container = grid.containers.create!(container_id: SecureRandom.hex(16), name: 'foo-1')
+      subject.on_container_log(grid, {
+        'id' => container.container_id,
+        'data' => 'foo',
+        'type' => 'stderr'
+      })
+      expect(container.container_logs.last.name).to eq(container.name)
+    end
+
+    it 'does not create entry if container does not exist' do
+      expect {
+        subject.on_container_log(grid, {
+          'id' => 'does_not_exist',
+          'data' => 'foo',
+          'type' => 'stderr'
+        })
+      }.to change{ grid.container_logs.count }.by(0)
+    end
+  end
 end


### PR DESCRIPTION
We should save container.name to logs so that we can find them with logical name (eg "redis-3").