### PR TITLE
Wait for port on deploy

### DIFF
--- a/app/helpers/request_helpers.rb
+++ b/app/helpers/request_helpers.rb
@@ -24,7 +24,12 @@ module RequestHelpers
   end
 
   def parse_json_body
-    JSON.parse(request.body.read)
+    body = request.body.read
+    if body == ''
+      {}
+    else
+      JSON.parse(body)
+    end
   rescue => exc
     response.status = 400
     response.write({error: 'Invalid json'}.to_json)

--- a/app/mutations/grid_services/deploy.rb
+++ b/app/mutations/grid_services/deploy.rb
@@ -18,6 +18,10 @@ module GridServices
       string :strategy, nils: true, default: 'ha'
     end
 
+    optional do
+      integer :wait_for_port
+    end
+
     def validate
       if self.grid_service.deploying?
         add_error(:service, :invalid_state, 'Service is currently deploying')
@@ -67,10 +71,18 @@ module GridServices
       if @deployer.nil?
         nodes = self.grid_service.grid.host_nodes.connected.to_a
         strategy = STRATEGIES[self.strategy].new
-        @deployer = GridServiceDeployer.new(strategy, self.grid_service, nodes)
+        @deployer = GridServiceDeployer.new(strategy, self.grid_service, nodes, deploy_options)
       end
 
       @deployer
+    end
+
+    ##
+    # @return [Hash]
+    def deploy_options
+      deploy_options = {}
+      deploy_options[:wait_for_port] = self.wait_for_port if self.wait_for_port
+      deploy_options
     end
   end
 end

--- a/app/routes/v1/services_api.rb
+++ b/app/routes/v1/services_api.rb
@@ -68,10 +68,10 @@ module V1
         # POST /v1/services/:id
         r.post do
           r.on('deploy') do
-            outcome = GridServices::Deploy.run(
-              current_user: current_user,
-              grid_service: grid_service
-            )
+            data = parse_json_body rescue {}
+            data[:current_user] = current_user
+            data[:grid_service] = grid_service
+            outcome = GridServices::Deploy.run(data)
             if outcome.success?
               audit_event(r, grid_service.grid, grid_service, 'deploy', grid_service)
               {}


### PR DESCRIPTION
This PR adds "wait_for_port" option to service deploy. If port is defined, service deployer will wait that port is open before proceeding to next container. 